### PR TITLE
fix: singleInteger validation always throwing Error

### DIFF
--- a/lib/moonridge-method-validations.js
+++ b/lib/moonridge-method-validations.js
@@ -9,6 +9,7 @@ var singleIntegerValidation = function (args) {
     if (!isInt(args[0])) {
       throw new TypeError('Argument must be an integer')
     }
+    return true
   }
   throw new Error('Method must be called with exactly one Number argument')
 }


### PR DESCRIPTION
Added return statement to allow for successful fn call when a single
integer arg is provided
